### PR TITLE
Fixed bug that malformes QR URL

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -74,7 +74,8 @@ class PHPGangsta_GoogleAuthenticator
      * @return string
      */
     public function getQRCodeGoogleUrl($name, $secret) {
-        return 'https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/'.$name.'%3Fsecret%3D'.$secret;
+        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
+        return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='.$urlencoded.'';
     }
 
     /**


### PR DESCRIPTION
Hi,

I've just spent 2 hours trying to figure out why my QR wouldn't show. If I visited the Google URL, it said it was malformed.

The problem the person is having here: http://stackoverflow.com/questions/11074191/google-2-factor-authentication-qr-code-issues is about the same problem I was having.

I eventually fixed this problem my applying a proper urlencode (yours was partially encoded already, but you forgot the user defined variables) and secondly by changing the URL from google.com to chart.googleapis.com. Don't ask me why but the latter seems to be working better.

Good luck and thanks for making this plugin!
