### PR TITLE
Add ability to use custom timeSlice in verifyCode like we have in getCode for more flexible usage.

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -88,11 +88,14 @@ class PHPGangsta_GoogleAuthenticator
      * @param string $secret
      * @param string $code
      * @param int $discrepancy This is the allowed time drift in 30 second units (8 means 4 minutes before or after)
+     * @param int|null $currentTimeSlice time slice if we want use other that time()
      * @return bool
      */
-    public function verifyCode($secret, $code, $discrepancy = 1)
+    public function verifyCode($secret, $code, $discrepancy = 1, $currentTimeSlice = null)
     {
-        $currentTimeSlice = floor(time() / 30);
+        if ($currentTimeSlice === null) {
+            $currentTimeSlice = floor(time() / 30);
+        }
 
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);


### PR DESCRIPTION
Add currentTimeSlice argument for verifyCode as same as in getCode method to be able to use other time than we have directly from time() (if we have other timezone in server settings for example)