### PR TITLE
Fix timing attack vulnerability

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -97,6 +97,10 @@ class PHPGangsta_GoogleAuthenticator
             $currentTimeSlice = floor(time() / 30);
         }
 
+        if (strlen($secret) != 6) {
+            return false;
+        }
+
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);
             $code = (int)$code;

--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -99,7 +99,9 @@ class PHPGangsta_GoogleAuthenticator
 
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);
-            if ($calculatedCode == $code ) {
+            $code = (int)$code;
+            $calculatedCode = (int)$calculatedCode;
+            if ($calculatedCode && $calculatedCode == $code ) {
                 return true;
             }
         }


### PR DESCRIPTION
This comparison is not timing safe
$calculatedCode == $code

Therefore, it's vulnerable to timing attack. This PR fixes it.