### PR TITLE
Avoid timing attacks and fix #24

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -99,7 +99,7 @@ class PHPGangsta_GoogleAuthenticator
 
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);
-            if ($calculatedCode == $code ) {
+            if ($this->timingSafeEquals($calculatedCode, $code)) {
                 return true;
             }
         }
@@ -204,5 +204,36 @@ class PHPGangsta_GoogleAuthenticator
             'Y', 'Z', '2', '3', '4', '5', '6', '7', // 31
             '='  // padding char
         );
+    }
+
+    /**
+     * A timing safe equals comparison
+     * more info here: http://blog.ircmaxell.com/2014/11/its-all-about-time.html
+     *
+     * @param string $safeString The internal (safe) value to be checked
+     * @param string $userString The user submitted (unsafe) value
+     *
+     * @return boolean True if the two strings are identical.
+     */
+    private function timingSafeEquals($safeString, $userString)
+    {
+        if (function_exists('hash_equals')) {
+            return hash_equals($safeString, $userString);
+        }
+        $safeLen = strlen($safeString);
+        $userLen = strlen($userString);
+
+        if ($userLen != $safeLen) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $userLen; $i++) {
+            $result |= (ord($safeString[$i]) ^ ord($userString[$i]));
+        }
+
+        // They are only identical strings if $result is exactly 0...
+        return $result === 0;
     }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -82,9 +82,22 @@ class GoogleAuthenticatorTest extends PHPUnit_Framework_TestCase {
 
     }
 
+    public function testVerifyCodeWithLeadingZero()
+    {
+        $secret = 'SECRET';
+        $code = $this->googleAuthenticator->getCode($secret);
+        $result = $this->googleAuthenticator->verifyCode($secret, $code);
+        $this->assertEquals(true, $result);
+
+        $code = '0'.$code;
+        $result = $this->googleAuthenticator->verifyCode($secret, $code);
+        $this->assertEquals(false, $result);
+
+    }
+
     public function testsetCodeLength()
     {
         $result = $this->googleAuthenticator->setCodeLength(6);
         $this->assertInstanceOf('PHPGangsta_GoogleAuthenticator', $result);
     }
-} 
+}


### PR DESCRIPTION
Time attacks can be used to improve one Brute Force attack
More info can be found here:
http://blog.ircmaxell.com/2014/11/its-all-about-time.html
http://sakurity.com/blog/2015/07/18/2fa.html

This comparison will also avoid the problem of leading zeros  (#24) :)