### PR TITLE
Remove hard-coded version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "phpgangsta/googleauthenticator",
     "description": "Google Authenticator 2-factor authentication",
-    "version": "1.0.0",
     "type": "library",
     "keywords": ["GoogleAuthenticator", "TOTP", "rfc6238"],
     "license": "BSD-4-Clause",


### PR DESCRIPTION
Adding the version to the composer.json makes it impossible to use this library via Composer without specifying the exact commit.