### PR TITLE
rawurlencode the name

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -104,7 +104,7 @@ class PHPGangsta_GoogleAuthenticator
         $height = !empty($params['height']) && (int) $params['height'] > 0 ? (int) $params['height'] : 200;
         $level = !empty($params['level']) && array_search($params['level'], array('L', 'M', 'Q', 'H')) !== false ? $params['level'] : 'M';
 
-        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
+        $urlencoded = urlencode('otpauth://totp/'.rawurlencode($name).'?secret='.$secret.'');
         if (isset($title)) {
             $urlencoded .= urlencode('&issuer='.urlencode($title));
         }


### PR DESCRIPTION
The name of the account must be encoded with rawurlencode(). Otherwise it will fail to add on iOS devices if the name contains a space for example.