### PR TITLE
Fix double urlencode

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -106,7 +106,7 @@ class PHPGangsta_GoogleAuthenticator
 
         $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
         if (isset($title)) {
-            $urlencoded .= urlencode('&issuer='.urlencode($title));
+            $urlencoded .= urlencode('&issuer='.$title);
         }
 
         return "https://api.qrserver.com/v1/create-qr-code/?data=$urlencoded&size=${width}x${height}&ecc=$level";


### PR DESCRIPTION
Double encoding caused some issues, for example, spaces in the title would appear as +'s when decoded.