### PR TITLE
Add Exception when paramater is less than 6 for setCodeLength

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -151,6 +151,10 @@ class PHPGangsta_GoogleAuthenticator
      */
     public function setCodeLength($length)
     {
+        if ($length < 6) {
+            throw new Exception('Invalid code length, should be >= 6');
+        }
+
         $this->_codeLength = $length;
 
         return $this;


### PR DESCRIPTION
The function setCodeLength sais in the docblock that it's parameter value should be 6 or greater. This actually adds an exception when a length < 6 is passed to the function.