### PR TITLE
Changed QR Code

### DIFF
--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -104,7 +104,7 @@ class PHPGangsta_GoogleAuthenticator
         $height = !empty($params['height']) && (int) $params['height'] > 0 ? (int) $params['height'] : 200;
         $level = !empty($params['level']) && array_search($params['level'], array('L', 'M', 'Q', 'H')) !== false ? $params['level'] : 'M';
 
-        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
+        $urlencoded = urlencode('otpauth://totp/'.(isset($title) ? urlencode($title).':':'').$name.'?secret='.$secret.'');
         if (isset($title)) {
             $urlencoded .= urlencode('&issuer='.urlencode($title));
         }


### PR DESCRIPTION
The QR-Code requires the title to be in front of the name seperated by ':' to be displayed in apps like Authy